### PR TITLE
Add src/ alias for Jest

### DIFF
--- a/cli/scripts/test.js
+++ b/cli/scripts/test.js
@@ -60,6 +60,7 @@ module.exports = function(argv) {
     modulePaths: [],
     moduleNameMapper: {
       '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+      '^src\\/(.*)$': '<rootDir>/src/$1',
       '^react$': '<rootDir>/node_modules/react',
     },
     moduleFileExtensions: ['web.js', 'js', 'json', 'node'],


### PR DESCRIPTION
Allow using `src` inside Jest, so we can use `jest.require` and all its instances for files in our codebase.