### PR TITLE
Add callbacks for `.success()` and `.failure()` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ The app is based on [react-scripts](https://github.com/facebook/create-react-app
 
   All `new Action()` constructions inside `/src/collections/*/actions.js` will be transformed into `createAction` exported by `dreact/helper-actions`.
 
+- #### Success/Failure callbacks for actions
+
+  Each `.success()` and `.failure()` actions trigger callbacks passed to `.init()` action.
+
+  For example, when we initialize any action we can pass `onSuccess` and `onFailure` callbacks which will be triggered when corresponding success and failure actions are dispatched.
+
+  ```js
+  const message = new Action({
+    init: data => data, // It's important to pass values
+  })
+
+  const action = message.init({
+    text: 'hello',
+    onSuccess: () => alert('Message has been sent'),
+    onFailure: () => alert('Failed to send message'),
+  })
+  dispatch(action)
+
+  dispatch(message.success()) // Triggers `onSuccess` callback
+  dispatch(message.failure()) // Triggers `onFailure` callback
+  ```
+
 - #### Linting
 
   We use eslint and stylelint to lint our files. Also we applied several custom rules there to reach our needs: we request named exports for collection stuff, we request using normal functions to define components, we require tests for each file in the app. [Take a look at all rules](./cli/environment/eslint-plugin-local).

--- a/examples/basic/src/collections/Messages/actions.js
+++ b/examples/basic/src/collections/Messages/actions.js
@@ -1,0 +1,3 @@
+export const saveMessage = new Action({
+  init: data => data,
+})

--- a/examples/basic/src/collections/Messages/saga.js
+++ b/examples/basic/src/collections/Messages/saga.js
@@ -1,5 +1,23 @@
 import { effects } from 'dreact/helper-store'
 
+import * as actions from './actions'
+
+function* saveMessage() {
+  yield console.log('[saveMessage][saga] started')
+
+  yield effects.delay(1000)
+  yield console.log('[saveMessage][saga] will trigger success')
+  yield effects.put(actions.saveMessage.success())
+
+  yield effects.delay(1000)
+  yield console.log('[saveMessage][saga] will trigger failure')
+  yield effects.put(actions.saveMessage.failure())
+}
+
 export default function*() {
-  yield effects.all([])
+  yield effects.all([
+    effects.call(function* watchBasicActions() {
+      yield effects.takeEvery(actions.saveMessage.INIT, saveMessage)
+    }),
+  ])
 }

--- a/examples/basic/src/collections/Messages/use.js
+++ b/examples/basic/src/collections/Messages/use.js
@@ -1,10 +1,12 @@
 import { useCallback } from 'react'
-import { useSelector } from 'dreact/helper-store'
+import { useDispatch } from 'dreact/helper-store'
 
-export function useTriggerSayHello() {
-  useSelector(s => console.log(s))
+import * as actions from './actions'
+
+export function useTriggerSayHello(callbacks) {
+  const dispatch = useDispatch()
 
   return useCallback(() => {
-    console.log('a')
-  })
+    dispatch(actions.saveMessage.init({ ...callbacks, text: 'Hello' }))
+  }, [])
 }

--- a/examples/basic/src/components/Message/index.js
+++ b/examples/basic/src/components/Message/index.js
@@ -5,7 +5,10 @@ const Test = styled.div`
 `
 
 function Message(props) {
-  const trigger = useTriggerSayHello()
+  const trigger = useTriggerSayHello({
+    onSuccess: () => console.log('Success Callback'),
+    onFailure: () => console.log('Failure Callback'),
+  })
 
   return pug`
     p Hello from component

--- a/helper-store/index.js
+++ b/helper-store/index.js
@@ -3,6 +3,7 @@ import createSagaMiddleware from 'redux-saga'
 import * as sagaEffects from 'redux-saga/effects'
 
 import errorCatcher from '../helper-sentry'
+import sagaHandleCallbacks from './saga.handleCallbacks'
 
 function makeStoreConfigurer(params) {
   if (process.env.NODE_ENV !== 'production') {
@@ -33,7 +34,10 @@ function makeStoreConfigurer(params) {
 
   function* rootSaga(run) {
     const task = yield sagaEffects.fork(function*() {
-      yield sagaEffects.all(params.sagas.map(saga => sagaEffects.call(saga)))
+      yield sagaEffects.all([
+        ...params.sagas.map(saga => sagaEffects.call(saga)),
+        sagaEffects.call(sagaHandleCallbacks),
+      ])
     })
 
     yield sagaEffects.take(RESTART.type)

--- a/helper-store/saga.handleCallbacks.js
+++ b/helper-store/saga.handleCallbacks.js
@@ -1,0 +1,31 @@
+import _ from 'lodash'
+import { takeEvery, take, delay, cancel, fork } from 'redux-saga/effects'
+
+const MAX_WAITING_FOR_ACTION = 20000
+
+const INIT_PATTERN = /\/INIT$/
+
+const isInitAction = action => INIT_PATTERN.test(action.type)
+const getActionType = (type, target) => type.replace(INIT_PATTERN, `/${target}`)
+
+export default function*() {
+  yield takeEvery(isInitAction, function*({ type, payload }) {
+    const onSuccessHandler = _.defaultTo(payload.onSuccess, _.noop)
+    const onFailureHandler = _.defaultTo(payload.onFailure, _.noop)
+
+    const successWatcher = yield fork(function*() {
+      const action = yield take(getActionType(type, 'SUCCESS'))
+      onSuccessHandler(action.payload)
+    })
+
+    const failureWatcher = yield fork(function*() {
+      const action = yield take(getActionType(type, 'FAILURE'))
+      onFailureHandler(action.payload)
+    })
+
+    yield delay(MAX_WAITING_FOR_ACTION)
+
+    yield cancel(successWatcher)
+    yield cancel(failureWatcher)
+  })
+}


### PR DESCRIPTION
Add the possibility to pass callbacks for `.success()` and `.failure()` actions within corresponding `.init()`