### PR TITLE
Make sure `dreact lint js` exits with correct exit code when eslint find errors

### DIFF
--- a/cli/scripts/lint.js
+++ b/cli/scripts/lint.js
@@ -8,16 +8,20 @@ const getConfigPath = name => path.resolve(__dirname, '..', 'environment', name)
 module.exports = function (argv) {
   if (argv[0] === 'js') {
     const configPath = getConfigPath('eslint.config.js')
-    process.exitCode = eslintCli.execute([
-      'eslint',
-      '--no-eslintrc',
-      '--config',
-      configPath,
-      '--ignore-path',
-      path.resolve(process.cwd(), '.gitignore'),
-      ...argv.slice(1),
-      './',
-    ])
+
+    ;(async function main() {
+      process.exitCode = await eslintCli.execute([
+        'eslint',
+        '--no-eslintrc',
+        '--config',
+        configPath,
+        '--ignore-path',
+        path.resolve(process.cwd(), '.gitignore'),
+        ...argv.slice(1),
+        './',
+      ])
+    })()
+
     return
   }
 


### PR DESCRIPTION
This fixes #34 
